### PR TITLE
feat: Use Covalent API to get ERC721 Contract Data

### DIFF
--- a/contracts/Migrations.json
+++ b/contracts/Migrations.json
@@ -2180,10 +2180,16 @@
       "links": {},
       "address": "0xaF7fC2F4D456712bA3170Ad31D7E4389e76facf7",
       "transactionHash": "0xcc7293ad6403c38ecad104f45a2d9bbcd9d6a04ecd6cf13c5fa96ad5d796a032"
+    },
+    "42": {
+      "events": {},
+      "links": {},
+      "address": "0x2B99203DA4E02aFCbc8b0e4AC21C0505Aaa36fe8",
+      "transactionHash": "0x46bfd84b9aa96b1f83ae3ef59e2bad3c8ada28e7dc445c20730b102f9daf1899"
     }
   },
   "schemaVersion": "3.4.3",
-  "updatedAt": "2022-02-20T15:20:48.181Z",
+  "updatedAt": "2022-03-14T03:53:20.653Z",
   "networkType": "ethereum",
   "devdoc": {
     "kind": "dev",

--- a/contracts/PolyechoSample.json
+++ b/contracts/PolyechoSample.json
@@ -22839,10 +22839,16 @@
       "links": {},
       "address": "0xE9b33ABb18C5ebe1Edc1F15E68DF651F1766e05E",
       "transactionHash": "0x25762cd8f2adad2a019ab546f0f2a1cd8dcb77d3520b10cba6c1475793edceda"
+    },
+    "42": {
+      "events": {},
+      "links": {},
+      "address": "0x02c4018D3A1966813a56bEbe1D89A7B8ec34b01E",
+      "transactionHash": "0x9d92bb607c6fdff9f7a94ea10193f511defdb7769e9e3cbb07ab2d170f0fe96b"
     }
   },
   "schemaVersion": "3.4.3",
-  "updatedAt": "2022-02-20T15:20:48.176Z",
+  "updatedAt": "2022-03-14T03:53:20.646Z",
   "networkType": "ethereum",
   "devdoc": {
     "kind": "dev",

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
 		CLIENT_HOST: process.env.CLIENT_HOST,
 		BLOCKNATIVE_KEY: process.env.BLOCKNATIVE_KEY,
 		NFT_STORAGE_KEY: process.env.NFT_STORAGE_KEY,
+		COVALENT_API_KEY: process.env.COVALENT_API_KEY,
 		PYTHON_HTTP_HOST: process.env.PYTHON_HTTP_HOST,
 	},
 	images: {

--- a/pages/nfts/[id].tsx
+++ b/pages/nfts/[id].tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Container, Divider, Grid, Typography } from '@mui/material'
+import { Box, Button, Container, Divider, Grid, Paper, Typography } from '@mui/material'
 import type { GetServerSideProps, NextPage } from 'next'
 import Head from 'next/head'
 import Link from 'next/link'
@@ -27,9 +27,23 @@ const styles = {
 		color: '#a8a8a8',
 	},
 	btn: {
-		m: 1,
+		mb: 2,
 		display: 'block',
 		textAlign: 'center',
+	},
+	covalentWrap: {
+		p: 2,
+		mb: 2,
+		background: '#fafafa',
+		border: '1px solid #ccc',
+		textAlign: 'center',
+	},
+	covalentBtn: {
+		my: 2,
+	},
+	covalentMeta: {
+		display: 'block',
+		mb: 0.5,
 	},
 	divider: {
 		my: 3,
@@ -67,6 +81,16 @@ const styles = {
 }
 
 const propTypes = {
+	covalentData: PropTypes.shape({
+		items: PropTypes.arrayOf(
+			PropTypes.shape({
+				contract_address: PropTypes.string.isRequired,
+				nft_transactions: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+				type: PropTypes.string.isRequired,
+			}),
+		).isRequired,
+		updated_at: PropTypes.string.isRequired,
+	}).isRequired,
 	data: PropTypes.shape({
 		token: PropTypes.shape({
 			blockNumber: PropTypes.number.isRequired,
@@ -93,7 +117,8 @@ const propTypes = {
 type NftDetailsPageProps = PropTypes.InferProps<typeof propTypes>
 
 const NftDetailsPage: NextPage<NftDetailsPageProps> = props => {
-	const { data } = props
+	const { covalentData, data } = props
+	const contractData = covalentData.items[0]
 
 	return (
 		<>
@@ -113,7 +138,7 @@ const NftDetailsPage: NextPage<NftDetailsPageProps> = props => {
 					{data ? (
 						<>
 							<Grid container spacing={4}>
-								<Grid item xs={12} md={8}>
+								<Grid item xs={12} md={5}>
 									<Box>
 										<Typography variant="h4" component="h2" sx={styles.title}>
 											NFT Details
@@ -159,18 +184,44 @@ const NftDetailsPage: NextPage<NftDetailsPageProps> = props => {
 											</Link>
 										</Typography>
 									</Box>
-								</Grid>
-								<Grid item xs={12} md={4}>
 									<Link href={data.metadataUrl} passHref>
 										<Button color="secondary" variant="outlined" fullWidth size="large" sx={styles.btn}>
-											View on IPFS
+											View NFT Metadata on IPFS
 										</Button>
 									</Link>
-									<Link href={data.audioHref} passHref>
+									<Link href="ipfs://[cid]/blob" passHref>
 										<Button color="secondary" variant="outlined" fullWidth size="large" sx={styles.btn}>
-											Listen on IPFS
+											Listen to the Music NFT
 										</Button>
 									</Link>
+								</Grid>
+								<Grid item xs={12} md={7}>
+									{contractData && (
+										<Paper elevation={2} sx={styles.covalentWrap}>
+											<Typography variant="h5" gutterBottom>
+												ERC-721 Smart Contract Details
+											</Typography>
+											<Typography gutterBottom variant="body1">
+												<Link href={`https://kovan.etherscan.io/address/${contractData.contract_address}`} passHref>
+													<Button color="secondary" size="small" variant="outlined" sx={styles.covalentBtn}>
+														View Kovan Contract
+													</Button>
+												</Link>
+											</Typography>
+											<Typography variant="overline" sx={styles.covalentMeta}>
+												<strong>Contract Type:</strong> {contractData.type.toUpperCase()}
+											</Typography>
+											<Typography variant="overline" sx={styles.covalentMeta}>
+												<strong>Total Transactions:</strong> {contractData.nft_transactions.length}
+											</Typography>
+											<Typography variant="overline" sx={styles.covalentMeta}>
+												Last Updated: {formatDate(covalentData.updated_at)}
+											</Typography>
+											<Typography variant="overline" sx={styles.covalentMeta}>
+												Powered by <Link href="https://www.covalenthq.com/">Covalent</Link>
+											</Typography>
+										</Paper>
+									)}
 								</Grid>
 							</Grid>
 							<Divider light sx={styles.divider} />
@@ -240,16 +291,19 @@ export const getServerSideProps: GetServerSideProps = async context => {
 	const data: any | null = res.success ? res.data : null
 
 	// Get data via Covalent API
-	const contractAddress = '0xe9b33abb18c5ebe1edc1f15e68df651f1766e05e' // ERC-721 PolyEchoSample contract
-	const chainId = 4 // Rinkeby
-	const tokenId = 1 // Get latest from smart contract using web3.js
-	const url = `https://api.covalenthq.com/v1/${chainId}/tokens/${contractAddress}/nft_metadata/${tokenId}/?quote-currency=USD&format=JSON&key=${process.env.COVALENT_API_KEY}`
-	const covalentRes = await fetch(url)
-	console.log({ covalentRes })
-	const covalentData = covalentRes.ok ? covalentRes.json() : null
-	console.log({ covalentData })
+	// const contractAddress = '0xe9b33abb18c5ebe1edc1f15e68df651f1766e05e' // ERC-721 PolyEchoSample contract (Rinkeby)
+	const contractAddress = '0x02c4018D3A1966813a56bEbe1D89A7B8ec34b01E' // ERC-721 PolyEchoSample contract (Kovan)
+	const chainId = 42 // Kovan
+	const tokenId = 0 // Get latest from smart contract using web3.js
+	// const tokenIdsUrl = `https://api.covalenthq.com/v1/${chainId}/tokens/${contractAddress}/nft_token_ids/?&key=${process.env.COVALENT_API_KEY}`
+	// const metadataUrl = `https://api.covalenthq.com/v1/${chainId}/tokens/${contractAddress}/nft_metadata/${tokenId}/?quote-currency=USD&format=JSON&key=${process.env.COVALENT_API_KEY}`
+	const transactionsUrl = `https://api.covalenthq.com/v1/${chainId}/tokens/${contractAddress}/nft_transactions/${tokenId}/?quote-currency=USD&format=JSON&key=${process.env.COVALENT_API_KEY}`
+	const covalentRes = await fetch(transactionsUrl)
+	const covalentData = covalentRes.ok ? await covalentRes.json() : null
+
 	return {
 		props: {
+			covalentData: covalentData.data,
 			data,
 		},
 	}

--- a/pages/nfts/[id].tsx
+++ b/pages/nfts/[id].tsx
@@ -234,8 +234,20 @@ export const getServerSideProps: GetServerSideProps = async context => {
 	let nftId = context.query.id
 	if (typeof nftId === 'object') nftId = nftId[0].toLowerCase()
 	else nftId = nftId?.toLowerCase()
+
+	// Get NFT data from database
 	const res = await get(`/nfts/${nftId}`)
 	const data: any | null = res.success ? res.data : null
+
+	// Get data via Covalent API
+	const contractAddress = '0xe9b33abb18c5ebe1edc1f15e68df651f1766e05e' // ERC-721 PolyEchoSample contract
+	const chainId = 4 // Rinkeby
+	const tokenId = 1 // Get latest from smart contract using web3.js
+	const url = `https://api.covalenthq.com/v1/${chainId}/tokens/${contractAddress}/nft_metadata/${tokenId}/?quote-currency=USD&format=JSON&key=${process.env.COVALENT_API_KEY}`
+	const covalentRes = await fetch(url)
+	console.log({ covalentRes })
+	const covalentData = covalentRes.ok ? covalentRes.json() : null
+	console.log({ covalentData })
 	return {
 		props: {
 			data,

--- a/web3/truffle-config.js
+++ b/web3/truffle-config.js
@@ -1,8 +1,10 @@
 // Truffle config <http://truffleframework.com/docs/advanced/configuration>
 
+/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path')
 const HDWalletProvider = require('@truffle/hdwallet-provider')
 require('dotenv').config()
+/* eslint-enable @typescript-eslint/no-var-requires */
 
 const networkIds = {
 	mainnet: 1,
@@ -43,6 +45,7 @@ module.exports = {
 		mainnet: getInfuraNetworkConfig('mainnet'),
 		// Rinkeby
 		rinkeby: getInfuraNetworkConfig('rinkeby'),
+		kovan: getInfuraNetworkConfig('kovan'),
 		// Polygon testnet
 		// matic: {
 		// 	provider: () =>


### PR DESCRIPTION
- Deploys to Kovan network to test this, as Covalent doesn't support Rinkeby.

Now:
- Leverage getting smart contract data on NFT details view
  - Right now, just gets tokenID zero (first mint) and is querying Kovan
  - Gets transaction data around smart contract and displays number of transactions happened
  - https://www.covalenthq.com/docs/api/#/0/Get%20NFT%20token%20IDs%20for%20contract/USD/42
- Display some data in top right box on the page

Future:
- Query Arbitrum and/or Polygon smart contract address
- Query the given tokenID, not just zero
- To expand on viewing out each individual transfer for the given tokenID