### PR TITLE
chore: Add in smart contract tests

### DIFF
--- a/web3/test/PolyEchoNFT.test.js
+++ b/web3/test/PolyEchoNFT.test.js
@@ -2,20 +2,16 @@ const NFTContract = artifacts.require('PolyEchoNFT')
 
 contract('PolyEchoNFT: deployment', () => {
 	let contract
-	let nft
-	let tokenId
 
 	beforeEach(async () => {
 		contract = await NFTContract.deployed()
 	})
 
-	// Tests it can be deployed
 	it('has been deployed', async () => {
 		assert(contract, 'PolyEchoNFT contract was not deployed')
 		assert.notEqual(contract, undefined)
 	})
 
-	// Tests address for the PolyEchoNFT contract
 	it('Should have an address', () => {
 		const address = contract.address
 		assert.notEqual(address, 0x0)
@@ -24,44 +20,119 @@ contract('PolyEchoNFT: deployment', () => {
 		assert.notEqual(address, undefined)
 	})
 
-	// Tests name for the token of PolyEchoNFT contract
 	it('Should have a name', async () => {
-		// Returns the name of the token
 		const name = await contract.name()
 		assert.equal(name, 'PolyEcho')
 	})
 
-	// Tests symbol for the token of PolyEchoNFT contract
 	it('Should have a symbol', async () => {
-		// Returns the symbol of the token
 		const symbol = await contract.symbol()
 		assert.equal(symbol, 'ECHO')
 	})
 })
 
-contract('PolyEchoNFT: minting', () => {
+contract('PolyEchoNFT: properties', accounts => {
+	let contract
+	const owner = accounts[0]
+
+	beforeEach(async () => {
+		contract = await NFTContract.deployed()
+	})
+
+	it('Should have a display name', async () => {
+		const displayName = await contract.displayName()
+		assert.equal(displayName, 'PolyEcho Audio NFT')
+	})
+
+	it('Should have a company name', async () => {
+		const companyName = await contract.companyName()
+		assert.equal(companyName, 'PolyEcho')
+	})
+
+	describe('editing displayName', () => {
+		it('Should be able to update the display name', async () => {
+			const displayName = await contract.displayName()
+			assert.equal(displayName, 'PolyEcho Audio NFT')
+		})
+
+		it('should emit the NameUpdated event', async () => {
+			const tx = await contract.updateDisplayName('Genesis Collection', {
+				from: owner,
+			})
+			const expectedEvent = 'NameUpdated'
+			const actualEvent = tx.logs[0].event
+			assert.equal(actualEvent, expectedEvent, 'events should match')
+		})
+	})
+})
+
+contract('PolyEchoNFT: mintAndBuy()', accounts => {
+	let contract
+	const owner = accounts[0]
+	const minter = accounts[1]
+	const metadataURI1 = 'ipfs://some-test-CID-1'
+	const metadataURI2 = 'ipfs://some-test-CID-2'
+	const contributors = [accounts[2], accounts[3], accounts[3]]
+
+	beforeEach(async () => {
+		contract = await NFTContract.deployed()
+	})
+
+	it('Should have a static mint price', async () => {
+		const mintPrice = await contract.mintPrice()
+		assert.equal(mintPrice, 10000000000000000)
+	})
+
+	it('Throws an error if sender sends less than the mint price', async () => {
+		try {
+			await contract.mintAndBuy(minter, metadataURI1, contributors)
+		} catch (err) {
+			const expectedError = 'Sent ether value is not enough to mint'
+			const actualError = err.reason
+			assert.equal(actualError, expectedError, 'should not be permitted')
+		}
+	})
+
 	// Tests for NFT minting function of PolyEchoNFT contract using tokenID of the minted NFT
-	it.skip('Should be able to mint NFT', async () => {
-		// Mints a NFT
-		let txn = await nft.createPolyEchoNFT()
-		let tx = await txn.wait()
+	it('Should be able to mint NFTs with proper metadata', async () => {
+		// Mint a token
+		const mintPrice = await contract.mintPrice()
+		let tx = await contract.mintAndBuy(minter, metadataURI1, contributors, {
+			value: mintPrice,
+		})
 
-		// tokenID of the minted NFT
-		let event = tx.events[0]
-		let value = event.args[2]
-		tokenId = value.toNumber()
+		// Test tokenID and URI
+		let tokenId = tx.logs[0].args[2].toNumber()
+		let actualMetadataURI = tx.logs[2].args._tokenURI
+		assert.equal(tokenId, 1, 'tokenID should start with 1')
+		assert.equal(actualMetadataURI, metadataURI1, 'metadata URIs should match')
 
-		assert.equal(tokenId, 0)
+		// Emits the custom TokenCreated event
+		const expectedEvent = 'TokenCreated'
+		let actualEvent = tx.logs[2].event
+		assert.equal(actualEvent, expectedEvent, 'events should match')
 
-		// Mints another NFT
-		txn = await nft.createPolyEchoNFT()
-		tx = await txn.wait()
+		// Mint another token and test incremented tokenID
+		tx = await contract.mintAndBuy(minter, metadataURI2, contributors, {
+			value: mintPrice,
+		})
+		tokenId = tx.logs[0].args[2].toNumber()
+		actualMetadataURI = tx.logs[2].args._tokenURI
+		assert.equal(tokenId, 2, 'tokenID should be incremented')
+		assert.equal(actualMetadataURI, metadataURI2, 'metadata URIs should match')
+		const tokenIdURIState = await contract.tokenIdToUri()[tokenId - 1]
+		assert.equal(tokenIdURIState, actualMetadataURI, 'state should be equal')
+	})
 
-		// tokenID of the minted NFT
-		event = tx.events[0]
-		value = event.args[2]
-		tokenId = value.toNumber()
-
-		assert.equal(tokenId, 1)
+	// TODO:
+	it.skip('Should pay out the mint price evenly to contributors', async () => {
+		const mintPrice = await contract.mintPrice()
+		const expectedContributorCut = mintPrice / contributors.length
+		const tx = await contract.mintAndBuy(minter, metadataURI1, contributors, {
+			value: mintPrice,
+		})
+		// It is possible that we should emit an event for each transfer to a contributor, and test that way
+		const actualContributors = await contract.tokenIdToContributors(0)
+		assert.equal(actualContributors, contributors, 'contributors should be tied to the newly minted tokenID')
 	})
 })

--- a/web3/test/PolyEchoNFT.test.js
+++ b/web3/test/PolyEchoNFT.test.js
@@ -1,64 +1,67 @@
 const NFTContract = artifacts.require('PolyEchoNFT')
 
-contract('PolyEchoNFT', accounts => {
+contract('PolyEchoNFT: deployment', () => {
+	let contract
 	let nft
 	let tokenId
 
+	beforeEach(async () => {
+		contract = await NFTContract.deployed()
+	})
+
 	// Tests it can be deployed
 	it('has been deployed', async () => {
-		const contract = await NFTContract.deployed()
 		assert(contract, 'PolyEchoNFT contract was not deployed')
 		assert.notEqual(contract, undefined)
 	})
 
-	// // Tests address for the EternalNFT contract
-	// it('Should have an address', async () => {
-	// 	const contract = await NFTContract.deployed()
-	// 	const address = await contract.address()
-	// 	assert.notEqual(address, 0x0)
-	// 	assert.notEqual(address, '')
-	// 	assert.notEqual(address, null)
-	// 	assert.notEqual(address, undefined)
-	// })
+	// Tests address for the PolyEchoNFT contract
+	it('Should have an address', () => {
+		const address = contract.address
+		assert.notEqual(address, 0x0)
+		assert.notEqual(address, '')
+		assert.notEqual(address, null)
+		assert.notEqual(address, undefined)
+	})
 
-	// // Tests name for the token of EternalNFT contract
-	// it('Should have a name', async () => {
-	// 	// Returns the name of the token
-	// 	const name = await nft.collectionName()
+	// Tests name for the token of PolyEchoNFT contract
+	it('Should have a name', async () => {
+		// Returns the name of the token
+		const name = await contract.name()
+		assert.equal(name, 'PolyEcho')
+	})
 
-	// 	assert.equal(name, 'EternalNFT')
-	// })
+	// Tests symbol for the token of PolyEchoNFT contract
+	it('Should have a symbol', async () => {
+		// Returns the symbol of the token
+		const symbol = await contract.symbol()
+		assert.equal(symbol, 'ECHO')
+	})
+})
 
-	// // Tests symbol for the token of EternalNFT contract
-	// it('Should have a symbol', async () => {
-	// 	// Returns the symbol of the token
-	// 	const symbol = await nft.collectionSymbol()
+contract('PolyEchoNFT: minting', () => {
+	// Tests for NFT minting function of PolyEchoNFT contract using tokenID of the minted NFT
+	it.skip('Should be able to mint NFT', async () => {
+		// Mints a NFT
+		let txn = await nft.createPolyEchoNFT()
+		let tx = await txn.wait()
 
-	// 	assert.equal(symbol, 'ENFT')
-	// })
+		// tokenID of the minted NFT
+		let event = tx.events[0]
+		let value = event.args[2]
+		tokenId = value.toNumber()
 
-	// // Tests for NFT minting function of EternalNFT contract using tokenID of the minted NFT
-	// it('Should be able to mint NFT', async () => {
-	// 	// Mints a NFT
-	// 	let txn = await nft.createEternalNFT()
-	// 	let tx = await txn.wait()
+		assert.equal(tokenId, 0)
 
-	// 	// tokenID of the minted NFT
-	// 	let event = tx.events[0]
-	// 	let value = event.args[2]
-	// 	tokenId = value.toNumber()
+		// Mints another NFT
+		txn = await nft.createPolyEchoNFT()
+		tx = await txn.wait()
 
-	// 	assert.equal(tokenId, 0)
+		// tokenID of the minted NFT
+		event = tx.events[0]
+		value = event.args[2]
+		tokenId = value.toNumber()
 
-	// 	// Mints another NFT
-	// 	txn = await nft.createEternalNFT()
-	// 	tx = await txn.wait()
-
-	// 	// tokenID of the minted NFT
-	// 	event = tx.events[0]
-	// 	value = event.args[2]
-	// 	tokenId = value.toNumber()
-
-	// 	assert.equal(tokenId, 1)
-	// })
+		assert.equal(tokenId, 1)
+	})
 })

--- a/web3/test/PolyEchoNFT.test.js
+++ b/web3/test/PolyEchoNFT.test.js
@@ -120,18 +120,15 @@ contract('PolyEchoNFT: mintAndBuy()', accounts => {
 		actualMetadataURI = tx.logs[2].args._tokenURI
 		assert.equal(tokenId, 2, 'tokenID should be incremented')
 		assert.equal(actualMetadataURI, metadataURI2, 'metadata URIs should match')
-		const tokenIdURIState = await contract.tokenIdToUri()[tokenId - 1]
-		assert.equal(tokenIdURIState, actualMetadataURI, 'state should be equal')
 	})
 
-	// TODO:
+	// TODO: It is possible that we should emit an event for each transfer to a contributor, and test that way
 	it.skip('Should pay out the mint price evenly to contributors', async () => {
 		const mintPrice = await contract.mintPrice()
 		const expectedContributorCut = mintPrice / contributors.length
 		const tx = await contract.mintAndBuy(minter, metadataURI1, contributors, {
 			value: mintPrice,
 		})
-		// It is possible that we should emit an event for each transfer to a contributor, and test that way
 		const actualContributors = await contract.tokenIdToContributors(0)
 		assert.equal(actualContributors, contributors, 'contributors should be tied to the newly minted tokenID')
 	})


### PR DESCRIPTION
Adds in smart contract tests
- Covers all callable function within the smart contract
- Does not cover a few cases, but are noted as TODOs
  - Checking balances before and after for contributors from original mint
  - Checking balances before and after for seller from secondary sale
  - Checking balances before and after for contributors from secondary sale
  - Testing a third sale for an NFT and checking against balances